### PR TITLE
PCD-3198: Increase length of created_by , updated_by column to String…

### DIFF
--- a/mors_repo/versions/001_Add_initial_tables.py
+++ b/mors_repo/versions/001_Add_initial_tables.py
@@ -10,8 +10,8 @@ tenant_lease = Table(
     Column('action', String(40)),
     Column('created_at', DateTime),
     Column('updated_at', DateTime),
-    Column('created_by', String(40)),
-    Column('updated_by', String(40))
+    Column('created_by', String(64)),
+    Column('updated_by', String(64))
 )
 
 vm_lease = Table(
@@ -22,8 +22,8 @@ vm_lease = Table(
     Column('action', String(40)),
     Column('created_at', DateTime),
     Column('updated_at', DateTime),
-    Column('created_by', String(40)),
-    Column('updated_by', String(40))
+    Column('created_by', String(64)),
+    Column('updated_by', String(64))
 )
 
 def upgrade(migrate_engine):


### PR DESCRIPTION
…(64)

The current column size (String(40)) is insufficient for storing full Keystone user IDs specifically SSO user ids, which are up to 64 characters. This change updates the column size to prevent update failures when longer IDs are used.