### PR TITLE
PCD-3482: Validate instance lease expiry to be in the future

### DIFF
--- a/mors/lease_manager.py
+++ b/mors/lease_manager.py
@@ -131,6 +131,12 @@ class LeaseManager:
 
     def add_instance_lease(self, context, tenant_uuid, instance_lease_obj):
         logger.info("Add instance lease %s", instance_lease_obj)
+        
+        # Check if expiry time is in the future
+        current_time = datetime.utcnow()
+        if 'expiry' not in instance_lease_obj or instance_lease_obj['expiry'] <= current_time:
+            raise ValueError("Expiry time must be in the future")
+            
         tenant_lease = self.domain_mgr.get_tenant_lease(tenant_uuid)
         if not self.check_instance_lease_violation(instance_lease_obj, tenant_lease):
             if 'action' in instance_lease_obj:                            
@@ -142,7 +148,7 @@ class LeaseManager:
                                            instance_lease_obj['expiry'],             
                                            action,                                   
                                            context.user_id,                          
-                                           datetime.utcnow())  
+                                           current_time)  
         else:
             raise ValueError("Instance lease exceeds tenant lease")
 


### PR DESCRIPTION
### SUMMARY

updated the `add_instance_lease` function to include the expiry time validation. Here's what changed:

Added a check to ensure the expiry field exists in instance_lease_obj and that it's in the future compared to the current time.
If the validation fails, it raises a ValueError with a descriptive message.

The validation will now prevent setting an expiry time that is in the past or equal to the current time. The error message clearly indicates that the expiry time must be in the future.

**WHY?**
If the VM expiry time is in the past, it means one of two things:

- User mistake → They accidentally entered an old date/time.
- Intentional immediate deletion → They’re trying to shut it down right away by setting an expiry that’s already passed. ( We do have power off and delete options on the UI though) 

From a best practice & safety perspective:

We shouldn’t  automatically allow past expiry times — it could cause accidental and unexpected VM deletion.

Instead, we should validate and warn:

If expiry < current time → show a clear warning and ask for confirmation (“This will delete/power off the VM immediately. Are you sure?”).

Optionally, disallow it completely unless the user has elevated permissions or explicitly flags “delete now.”

As we already have explicit `Delete` and `Power Off`actions in the UI, then allowing users to set a past expiry time is redundant and risky.  We're `rejecting Past expiry` so that scheduling remains a future event only, while immediate actions stay under their dedicated commands.

### TESTING
**Manual**

Via API
```
# date
Wed Aug 13 13:44:08 UTC 2025
root@test-pf9-testbed-only-4008106-370-2:~# curl -k -X POST -H "X-Auth-Token: $TOKEN" -H "Content-Type: application/json" -i https://airctl-1-4008106-892-blr.platform9.localnet/mors/v1/tenant/bb92468d2bc5487ca712f3d141ce415e/instance/42c8f398-7907-4a3e-a9b7-3f0cedc3c47f  -d '{"instance_uuid": "42c8f398-7907-4a3e-a9b7-3f0cedc3c47f", "expiry" : "2025-08-13T13:55:00Z", "action": "power off"}'
HTTP/2 200 
date: Wed, 13 Aug 2025 13:46:43 GMT
content-type: application/json
content-length: 22
contenttype: application/json
strict-transport-security: max-age=31536000; includeSubDomains

{
  "success": true
}
root@test-pf9-testbed-only-4008106-370-2:~# curl -k -X POST -H "X-Auth-Token: $TOKEN" -H "Content-Type: application/json" -i https://airctl-1-4008106-892-blr.platform9.localnet/mors/v1/tenant/bb92468d2bc5487ca712f3d141ce415e/instance/42c8f398-7907-4a3e-a9b7-3f0cedc3c47f  -d '{"instance_uuid": "42c8f398-7907-4a3e-a9b7-3f0cedc3c47f", "expiry" : "2025-08-13T13:44:00Z", "action": "power off"}'
HTTP/2 422 
date: Wed, 13 Aug 2025 13:47:26 GMT
content-type: application/json
content-length: 51
contenttype: application/json
strict-transport-security: max-age=31536000; includeSubDomains

{
  "error": "Expiry time must be in the future"
}

```

Via UI
```
08-13 13:23 mors.lease_manager INFO     Add instance lease {'instance_uuid': 'e427b755-6527-44c5-9ac4-6971087940cb', 'expiry': datetime.datetime(2025, 8, 11, 18, 30), 'action': 'power off'}
Add instance lease {'instance_uuid': 'e427b755-6527-44c5-9ac4-6971087940cb', 'expiry': datetime.datetime(2025, 8, 11, 18, 30), 'action': 'power off'}
10.20.3.76,10.20.3.111 - - [13/Aug/2025 13:23:53] "POST /v1/tenant/bb92468d2bc5487ca712f3d141ce415e/instance/e427b755-6527-44c5-9ac4-6971087940cb HTTP/1.1" 422 208 0.003819
```

<img width="1347" height="716" alt="Screenshot 2025-08-13 at 6 54 02 PM" src="https://github.com/user-attachments/assets/7203a389-1899-4392-98df-9aa7a83c2c42" />
