### PR TITLE
Mors pod went in a not-responding state, needed restart due to scheduler failing/blocked/dead while a lease was implemented

### DIFF
--- a/container/etc/confd/templates/pf9-mors-api-paste.ini
+++ b/container/etc/confd/templates/pf9-mors-api-paste.ini
@@ -1,7 +1,15 @@
 [app:morsService]
 paste.app_factory = mors.mors_wsgi:app_factory
 
-[pipeline:main]
+[app:healthService]
+paste.app_factory = mors.mors_wsgi:health_app_factory
+
+[composite:main]
+use = egg:Paste#urlmap
+/health = healthService
+/ = authPipeline
+
+[pipeline:authPipeline]
 pipeline = authtoken morsService
 
 [filter:authtoken]

--- a/etc/pf9/pf9-mors-api-paste.ini
+++ b/etc/pf9/pf9-mors-api-paste.ini
@@ -1,8 +1,16 @@
-[app:myService]
+[app:morsService]
 paste.app_factory = mors.mors_wsgi:app_factory
 
-[pipeline:main]
-pipeline = authtoken  myService
+[app:healthService]
+paste.app_factory = mors.mors_wsgi:health_app_factory
+
+[composite:main]
+use = egg:Paste#urlmap
+/health = healthService
+/ = authPipeline
+
+[pipeline:authPipeline]
+pipeline = authtoken morsService
 
 [filter:authtoken]
 paste.filter_factory = keystonemiddleware.auth_token:filter_factory

--- a/mors/lease_manager.py
+++ b/mors/lease_manager.py
@@ -67,6 +67,8 @@ class LeaseManager:
         self.domain_mgr = DbPersistence(conf.get("DEFAULT", "db_conn"))
         self.lease_handler = get_lease_handler(conf)
         self.sleep_seconds = conf.getint("DEFAULT", "sleep_seconds")
+        self.last_run_time = None
+        self.scheduler_running = False
 
     def add_tenant_lease(self, context, tenant_obj):
         logger.info("Adding tenant lease %s", tenant_obj)
@@ -242,10 +244,67 @@ class LeaseManager:
             self.domain_mgr.delete_instance_leases(remove_from_db)
 
     def run(self):
-        # Delete the cleanup
-        tenant_leases = self.domain_mgr.get_all_tenant_leases()
-        for t_lease in tenant_leases:
-            self._delete_or_poweroff_vms_for_tenant(t_lease)
+        try:
+            self.scheduler_running = True
+            self.last_run_time = datetime.utcnow()
+            
+            # Delete the cleanup
+            tenant_leases = self.domain_mgr.get_all_tenant_leases()
+            for t_lease in tenant_leases:
+                self._delete_or_poweroff_vms_for_tenant(t_lease)
+            
+            logger.debug("Scheduler run completed at %s", self.last_run_time)
+        except Exception as e:
+            logger.error("Scheduler run failed: %s", str(e))
+            raise
+        finally:
+            self.scheduler_running = False
+            spawn_after(self.sleep_seconds, self.run)
 
-        # Sleep again for sleep_seconds
-        spawn_after(self.sleep_seconds, self.run)
+    def is_scheduler_healthy(self):
+        """
+        Check if the scheduler is healthy by verifying:
+        1. Last run time is within expected interval
+        2. Scheduler is not stuck in a running state for too long
+        """
+        if self.last_run_time is None:
+            return False, "Scheduler has never run"
+        
+        current_time = datetime.utcnow()
+        time_since_last_run = (current_time - self.last_run_time).total_seconds()
+
+        max_expected_interval = self.sleep_seconds * 2
+        
+        if time_since_last_run > max_expected_interval:
+            return False, f"Scheduler last ran {time_since_last_run:.0f}s ago, expected within {max_expected_interval}s"
+
+        estimated_max_runtime = self._estimate_max_scheduler_runtime()
+        
+        if self.scheduler_running and time_since_last_run > estimated_max_runtime:
+            return False, f"Scheduler appears stuck, running for {time_since_last_run:.0f}s (max expected: {estimated_max_runtime:.0f}s)"
+        
+        return True, "Scheduler is healthy"
+
+    def _estimate_max_scheduler_runtime(self):
+        """Race condition that migh happen if VMs are being deleted or powered off"""
+        try:
+            # total vms
+            total_vms = 0
+            tenant_leases = self.domain_mgr.get_all_tenant_leases()
+            
+            for t_lease in tenant_leases:
+                # Vm count
+                tenant_vms = self.lease_handler.get_all_vms(t_lease['tenant_uuid'])
+                total_vms += len(tenant_vms)
+            
+            # Estimate: 0.5s per VM operation + 10s base overhead + 50% safety buffer
+            estimated_time = (total_vms * 0.5) + 10
+            safety_buffer = estimated_time * 0.5
+            max_runtime = estimated_time + safety_buffer
+            
+            # Set bounds minimum 30s, maximum 300s (5 minutes)
+            return max(30, min(300, max_runtime))
+            
+        except Exception as e:
+            logger.warning("Could not estimate scheduler runtime: %s", str(e))
+            return 120

--- a/mors/mors_wsgi.py
+++ b/mors/mors_wsgi.py
@@ -23,6 +23,9 @@ DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 APP_NAME = "MORS"
 
 
+health_app = Flask("mors_health")
+
+
 class CustomJSONEncoder(JSONEncoder):
     def default(self, obj):
         try:
@@ -136,32 +139,45 @@ def shutdown_server():
         raise RuntimeError('Not running with the Werkzeug Server')
     func()
 
-@app.route("/health/live", methods=['GET'])
-def liveness_check():
-    """Liveness probe endpoint"""
-    return jsonify({"status": "alive", "service": APP_NAME}), 200
-
-@app.route("/health/ready", methods=['GET'])
-def readiness_check():
-    """Readiness probe endpoint"""
-    try:
-        if lease_manager is None:
-            return jsonify({"status": "not ready", "reason": "lease_manager not initialized"}), 503
-
-        lease_manager.domain_mgr.get_all_tenant_leases()
-
-        scheduler_healthy, scheduler_status = lease_manager.is_scheduler_healthy()
-        if not scheduler_healthy:
-            return jsonify({"status": "not ready", "reason": f"Scheduler unhealthy: {scheduler_status}"}), 503
-        
-        return jsonify({
-            "status": "ready", 
-            "service": APP_NAME,
-            "scheduler_status": scheduler_status,
-            "last_scheduler_run": lease_manager.last_run_time.isoformat() if lease_manager.last_run_time else None
-        }), 200
-    except Exception as e:
-        return jsonify({"status": "not ready", "reason": str(e)}), 503
 
 def app_factory(global_config, **local_conf):
     return app
+
+def health_app_factory(global_config, **local_conf):
+    """Factory for /health pipeline – only exposes health endpoints"""
+    from flask import Flask, jsonify
+
+    @health_app.route("/live", methods=["GET"])
+    def liveness_check():
+        return jsonify({"status": "alive", "service": APP_NAME}), 200
+
+    @health_app.route("/ready", methods=["GET"])
+    def readiness_check():
+        try:
+            if lease_manager is None:
+                return jsonify(
+                    {"status": "not ready", "reason": "lease_manager not initialized"}
+                ), 503
+
+            lease_manager.domain_mgr.get_all_tenant_leases()
+
+            scheduler_healthy, scheduler_status = lease_manager.is_scheduler_healthy()
+            if not scheduler_healthy:
+                return jsonify(
+                    {"status": "not ready", "reason": f"Scheduler unhealthy: {scheduler_status}"}
+                ), 503
+
+            return jsonify(
+                {
+                    "status": "ready",
+                    "service": APP_NAME,
+                    "scheduler_status": scheduler_status,
+                    "last_scheduler_run": lease_manager.last_run_time.isoformat()
+                    if lease_manager.last_run_time
+                    else None,
+                }
+            ), 200
+        except Exception as e:
+            return jsonify({"status": "not ready", "reason": str(e)}), 503
+
+    return health_app

--- a/mors/mors_wsgi.py
+++ b/mors/mors_wsgi.py
@@ -136,6 +136,32 @@ def shutdown_server():
         raise RuntimeError('Not running with the Werkzeug Server')
     func()
 
+@app.route("/health/live", methods=['GET'])
+def liveness_check():
+    """Liveness probe endpoint"""
+    return jsonify({"status": "alive", "service": APP_NAME}), 200
+
+@app.route("/health/ready", methods=['GET'])
+def readiness_check():
+    """Readiness probe endpoint"""
+    try:
+        if lease_manager is None:
+            return jsonify({"status": "not ready", "reason": "lease_manager not initialized"}), 503
+
+        lease_manager.domain_mgr.get_all_tenant_leases()
+
+        scheduler_healthy, scheduler_status = lease_manager.is_scheduler_healthy()
+        if not scheduler_healthy:
+            return jsonify({"status": "not ready", "reason": f"Scheduler unhealthy: {scheduler_status}"}), 503
+        
+        return jsonify({
+            "status": "ready", 
+            "service": APP_NAME,
+            "scheduler_status": scheduler_status,
+            "last_scheduler_run": lease_manager.last_run_time.isoformat() if lease_manager.last_run_time else None
+        }), 200
+    except Exception as e:
+        return jsonify({"status": "not ready", "reason": str(e)}), 503
 
 def app_factory(global_config, **local_conf):
     return app

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -197,10 +197,17 @@ def test_get_instance2():
 
 @test(depends_on=[test_get_instance2])
 def test_deleted_instance():
-    eventlet.greenthread.sleep(50)
-    # The instance lease should be deleted by now
-    r = requests.get('http://127.0.0.1:' + port + '/v1/tenant/' + tenant_id1 + '/instance/' + instance_id1,
-                     headers=headers)
+    timeout = time.time() + 90  # 90 seconds max wait
+    r = None
+    while time.time() < timeout:
+        r = requests.get(
+            'http://127.0.0.1:' + port + '/v1/tenant/' + tenant_id1 + '/instance/' + instance_id1,
+            headers=headers
+        )
+        logger.debug(f"Polling for deletion: status={r.status_code}")
+        if r.status_code == 404:
+            break
+        eventlet.greenthread.sleep(5) 
     logger.debug(r.text)
     assert_equal(r.status_code, 404)
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -151,7 +151,7 @@ def test_create_tenant_neg():
 @test(depends_on=[test_create_tenant_neg])
 def test_create_instance():
     # Now test the instance manipulation
-    expiry = datetime.utcnow()
+    expiry = datetime.utcnow() + timedelta(minutes=1)
     expiry_str = datetime.strftime(expiry, DATE_FORMAT)
     r = requests.post('http://127.0.0.1:' + port + '/v1/tenant/' + tenant_id1 + '/instance/' + instance_id1,
                       json={"instance_uuid": instance_id1, "expiry": expiry_str, "action": action1},
@@ -169,7 +169,7 @@ def test_get_instance():
 
 @test(depends_on=[test_get_instance])
 def test_update_instance():
-    expiry = datetime.utcnow()
+    expiry = datetime.utcnow() + timedelta(minutes=1)
     expiry_str = datetime.strftime(expiry, DATE_FORMAT)
     r = requests.put('http://127.0.0.1:' + port + '/v1/tenant/' + tenant_id1 + '/instance/' + instance_id1,
                       json={"instance_uuid": instance_id1, "expiry": expiry_str, "action": action1},
@@ -208,7 +208,7 @@ def test_deleted_instance():
 @test(depends_on=[test_deleted_instance])
 def test_create_instance2():
     # Now test the instance manipulation
-    expiry = datetime.utcnow()
+    expiry = datetime.utcnow() + timedelta(minutes=1)
     expiry_str = datetime.strftime(expiry, DATE_FORMAT)
     r = requests.post('http://127.0.0.1:' + port + '/v1/tenant/' + tenant_id1 + '/instance/' + instance_id2,
                       json={"instance_uuid": instance_id2, "expiry": expiry_str, "action": action2},
@@ -238,7 +238,7 @@ def test_create_tenant2():
 @test(depends_on=[test_create_tenant2])
 def test_create_instance3():
     # Now test the instance manipulation
-    expiry = datetime.utcnow()
+    expiry = datetime.utcnow() + timedelta(minutes=1)
     expiry_str = datetime.strftime(expiry, DATE_FORMAT)
     r = requests.post('http://127.0.0.1:' + port + '/v1/tenant/' + tenant_id2 + '/instance/' + instance_id3,
                       json={"tenant_uuid": tenant_id2, "instance_uuid": instance_id3, "expiry": expiry_str, "action": action2},

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 import os
 import sys;
-
+import time;
 import eventlet
 import requests
 from migrate.versioning.api import upgrade, version_control
@@ -197,7 +197,7 @@ def test_get_instance2():
 
 @test(depends_on=[test_get_instance2])
 def test_deleted_instance():
-    timeout = time.time() + 90  # 90 seconds max wait
+    timeout = time.time() + 90
     r = None
     while time.time() < timeout:
         r = requests.get(


### PR DESCRIPTION
Jira:-https://platform9.atlassian.net/browse/PCD-3717

TC builds container :- 
TC build pf9-mors :-https://teamcity.platform9.horse/buildConfiguration/Pf9project_Platform9Components_Pf9mors/4097167
TC testbed :- https://teamcity.platform9.horse/buildConfiguration/Pf9project_Opencloud_007pcdTestbedOnlyQa/4097424
Tested Upgrade/Fresh DU as well

Summary:- [LINK](https://platform9.atlassian.net/browse/PCD-3717?focusedCommentId=120557)
Helm PR:- https://github.com/platform9/pf9-openstack-helm/pull/405
    The issue is the lease was created successfully but the VM did not stop even in the logs the lease was not enforced as we have no logs of it even beyond that time. So either the scheduler handling that is either dead or blocked [resolution below]
    Adding liveness and readiness probe which will monitor and restart the pod
    But the above did not solve the scheduler issue as it does a superficial check so even if the scheduler gets blocked or dead it would still be valid and the same issue might come up
    So for that I have also added a function which verifies the scheduler is also healthy in the readiness probe so if it is not the pod will restart
    But the above logic had a race condition issue where we were assuming that the pod will compete the lease process within a second of time and if not  even if the scheduler might be healthy the readiness logic will return it as unhealthy which is incorrect
    So the above race condition is also taken care where we get the total vms count estimate a 0.5s per vm operation time and add some overhead just for safety set a bound where after that point we fail it below is an example of that the race condition

```
10 VMs × 0.5 sec = 5 sec
+ overhead (DB updates, API latency) ≈ 2–3 sec
Total ≈ 7–8 sec
```

TestCase changes:-

    In the testcase the expiry time was set to now which violates the API as it should be expiry > now. As beforehand this caused the server to return 422 UNPROCESSABLE ENTITY instead of 200 OK
    In the test_deleted_instance fixed sleep of 50s is inefficient as deletion happens earlier the test wastes time and if later even if it is valid it fails. So with pooling and timeout this is fixed as we check periodically every 5secs until success or timeout
  
Scheduler logic explanation
```
Last_run_time = 100s (when lease was called to stop vms at 200s) 
Current_time = 200s  (when lease called when the vms need to be stoped)
sleep_seconds = 60 (assumption)
scheduler_running = True (as when scheduler is called it is true)
total_vms = 5

time_since_last_run = current_time - last_run_time = 200-100 = 100s

max_expected_interval = 60*2=120s

time_since_last_run > max_expected_interval 100<=120 (scheduler is ok)

Race condition:-
estimated_time = 0.5*total_vms = 0.5*5+10 = 12.5s
with buffer 12.5 + 6.5 = 18.5 (sometimes faced delays)

max_runtime = max(30,min(300,18.75) = 30s

check if stuck time_since_last_run = 100s max_runtime = 30s 100s > 30s (scheduler seems stuck as 100s is way to much for stoping vms)
``` 
    
```
mors-84cd7c8bbd-dv98j:~# curl -v http://localhost:8989/     
* Host localhost:8989 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8989...
* connect to ::1 port 8989 from ::1 port 52430 failed: Connection refused
*   Trying 127.0.0.1:8989...
* Connected to localhost (127.0.0.1) port 8989
* using HTTP/1.x
> GET / HTTP/1.1
> Host: localhost:8989
> User-Agent: curl/8.12.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< Content-Type: application/json
< Content-Length: 47
< Date: Tue, 02 Sep 2025 11:23:28 GMT
< 
{
  "service": "MORS",
  "status": "running"
}
* Connection #0 to host localhost left intact
mors-84cd7c8bbd-dv98j:~# curl -v http://localhost:8989/health/live
* Host localhost:8989 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8989...
* connect to ::1 port 8989 from ::1 port 47090 failed: Connection refused
*   Trying 127.0.0.1:8989...
* Connected to localhost (127.0.0.1) port 8989
* using HTTP/1.x
> GET /health/live HTTP/1.1
> Host: localhost:8989
> User-Agent: curl/8.12.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< Content-Type: application/json
< Content-Length: 45
< Date: Tue, 02 Sep 2025 11:24:18 GMT
< 
{
  "service": "MORS",
  "status": "alive"
}
* Connection #0 to host localhost left intact
mors-84cd7c8bbd-dv98j:~# curl -v http://localhost:8989/v1
* Host localhost:8989 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8989...
* connect to ::1 port 8989 from ::1 port 36720 failed: Connection refused
*   Trying 127.0.0.1:8989...
* Connected to localhost (127.0.0.1) port 8989
* using HTTP/1.x
> GET /v1 HTTP/1.1
> Host: localhost:8989
> User-Agent: curl/8.12.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 401 Unauthorized
< Content-Type: application/json
< Content-Length: 114
< Www-Authenticate: Keystone uri="http://keystone.test-du-testbed-only-4038723.svc.cluster.local:5000/keystone/v3"
< Date: Tue, 02 Sep 2025 11:26:22 GMT
< 
* Connection #0 to host localhost left intact
{"error": {"code": 401, "title": "Unauthorized", "message": "The request you have made requires authentication."}}mors-84cd7c8bbd-dv98j:~# ^C
mors-84cd7c8bbd-dv98j:~# curl -v http://localhost:8989/health/ready
* Host localhost:8989 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8989...
* connect to ::1 port 8989 from ::1 port 38722 failed: Connection refused
*   Trying 127.0.0.1:8989...
* Connected to localhost (127.0.0.1) port 8989
* using HTTP/1.x
> GET /health/ready HTTP/1.1
> Host: localhost:8989
> User-Agent: curl/8.12.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< Content-Type: application/json
< Content-Length: 145
< Date: Tue, 02 Sep 2025 11:27:08 GMT
< 
{
  "last_scheduler_run": "2025-09-02T11:26:17.973474",
  "scheduler_status": "Scheduler is healthy",
  "service": "MORS",
  "status": "ready"
}
* Connection #0 to host localhost left intact
```