### PR TITLE
PCD-3880: Refined lease policy logic to prioritize VM-specific configurations over tenant-wide settings.

### DIFF
--- a/mors/lease_manager.py
+++ b/mors/lease_manager.py
@@ -133,7 +133,6 @@ class LeaseManager:
         if 'expiry' not in instance_lease_obj or instance_lease_obj['expiry'] <= current_time:
             raise ValueError("Expiry time must be in the future")
             
-        tenant_lease = self.domain_mgr.get_tenant_lease(tenant_uuid)
         if 'action' in instance_lease_obj:                            
             action = instance_lease_obj['action']                           
         else:                                                               
@@ -147,7 +146,6 @@ class LeaseManager:
 
     def update_instance_lease(self, context, tenant_uuid, instance_lease_obj):
         logger.info("Update instance lease %s", instance_lease_obj)
-        tenant_lease = self.domain_mgr.get_tenant_lease(tenant_uuid)
         self.domain_mgr.update_instance_lease(instance_lease_obj['instance_uuid'],
                                             tenant_uuid,
                                             instance_lease_obj['expiry'],
@@ -168,24 +166,20 @@ class LeaseManager:
     def _get_vms_to_delete_or_poweroff_for_tenant(self, tenant_uuid, expiry_mins, action):
         vms_to_delete = []
         vms_to_poweroff = []
-        vm_ids_to_delete = set()
-        vm_ids_to_poweroff = set()
         do_not_delete = set()
         now = datetime.utcnow()
         add_seconds = timedelta(seconds=expiry_mins*60)
         instance_leases = self.get_tenant_and_associated_instance_leases(None, tenant_uuid)['all_vms']
-        vm_lease_ids = []
+        vm_lease_ids = set()
         for i_lease in instance_leases:
-            vm_lease_ids.append(i_lease['instance_uuid'])
+            vm_lease_ids.add(i_lease['instance_uuid'])
             if now > i_lease['expiry']:
                 if i_lease['action'] == 'delete':
                      logger.info("Explicit lease for %s queueing for deletion", i_lease['instance_uuid'])
                      vms_to_delete.append(i_lease)
-                     vm_ids_to_delete.add(i_lease['instance_uuid'])
                 else:
                      logger.info("Explicit lease for %s queueing up to Power off", i_lease['instance_uuid'])
                      vms_to_poweroff.append(i_lease)
-                     vm_ids_to_poweroff.add(i_lease['instance_uuid'])
             else:
                 do_not_delete.add(i_lease['instance_uuid'])
                 logger.debug("Ignoring vm, vm not expired yet %s", i_lease['instance_uuid'])

--- a/mors/lease_manager.py
+++ b/mors/lease_manager.py
@@ -118,13 +118,6 @@ class LeaseManager:
                 [get_vm_lease_data(x) for x in self.domain_mgr.get_instance_leases_by_tenant(tenant_uuid)]
         }
 
-    def check_instance_lease_violation(self, instance_lease, tenant_lease):
-        violation = False
-        expiry = instance_lease['expiry']
-        if (datetime.utcnow() + timedelta(seconds=tenant_lease['expiry_mins']*60)) < expiry:
-            violation = True
-        return violation
-
     def get_instance_lease(self, context, instance_id):
         data = self.domain_mgr.get_instance_lease(instance_id)
         if data:
@@ -141,32 +134,27 @@ class LeaseManager:
             raise ValueError("Expiry time must be in the future")
             
         tenant_lease = self.domain_mgr.get_tenant_lease(tenant_uuid)
-        if not self.check_instance_lease_violation(instance_lease_obj, tenant_lease):
-            if 'action' in instance_lease_obj:                            
-                action = instance_lease_obj['action']                           
-            else:                                                               
-                action = DEFAULT_ACTION      
-            self.domain_mgr.add_instance_lease(instance_lease_obj['instance_uuid'],  
+        if 'action' in instance_lease_obj:                            
+            action = instance_lease_obj['action']                           
+        else:                                                               
+            action = DEFAULT_ACTION      
+        self.domain_mgr.add_instance_lease(instance_lease_obj['instance_uuid'],  
                                            tenant_uuid,                              
                                            instance_lease_obj['expiry'],             
                                            action,                                   
                                            context.user_id,                          
                                            current_time)  
-        else:
-            raise ValueError("Instance lease exceeds tenant lease")
 
     def update_instance_lease(self, context, tenant_uuid, instance_lease_obj):
         logger.info("Update instance lease %s", instance_lease_obj)
         tenant_lease = self.domain_mgr.get_tenant_lease(tenant_uuid)
-        if not self.check_instance_lease_violation(instance_lease_obj, tenant_lease):
-            self.domain_mgr.update_instance_lease(instance_lease_obj['instance_uuid'],
-                                              tenant_uuid,
-                                              instance_lease_obj['expiry'],
-                                              instance_lease_obj['action'],
-                                              context.user_id,
-                                              datetime.utcnow())
-        else:
-            raise ValueError("Instance lease exceeds tenant lease")
+        self.domain_mgr.update_instance_lease(instance_lease_obj['instance_uuid'],
+                                            tenant_uuid,
+                                            instance_lease_obj['expiry'],
+                                            instance_lease_obj['action'],
+                                            context.user_id,
+                                            datetime.utcnow())
+        
 
     def delete_instance_lease(self, context, instance_uuid):
         logger.info("Delete instance lease %s", instance_uuid)
@@ -186,7 +174,9 @@ class LeaseManager:
         now = datetime.utcnow()
         add_seconds = timedelta(seconds=expiry_mins*60)
         instance_leases = self.get_tenant_and_associated_instance_leases(None, tenant_uuid)['all_vms']
+        vm_lease_ids = []
         for i_lease in instance_leases:
+            vm_lease_ids.append(i_lease['instance_uuid'])
             if now > i_lease['expiry']:
                 if i_lease['action'] == 'delete':
                      logger.info("Explicit lease for %s queueing for deletion", i_lease['instance_uuid'])
@@ -201,11 +191,14 @@ class LeaseManager:
                 logger.debug("Ignoring vm, vm not expired yet %s", i_lease['instance_uuid'])
 
         tenant_vms = self.lease_handler.get_all_vms(tenant_uuid)
+        # Fetch all instance UUIDs that have explicit VM leases and skip them for tenant-level enforcement
         for vm in tenant_vms:
+            #If VM has an explicit VM lease, skip applying tenant default policy to it
+            if vm['instance_uuid'] in vm_lease_ids:
+                logger.debug("Skipping VM %s due to explicit VM lease", vm['instance_uuid'])
+                continue
             expiry_date = vm['created_at'] + add_seconds
-            if now > expiry_date and vm['instance_uuid'] not in vm_ids_to_delete \
-                                 and vm['instance_uuid'] not in vms_to_poweroff \
-                                 and vm['instance_uuid'] not in do_not_delete:
+            if now > expiry_date:
                 if action == 'delete':
                      logger.info("Instance %s queued up for deletion, creation date %s", vm['instance_uuid'],
                             vm['created_at'])


### PR DESCRIPTION
### JIRA
https://platform9.atlassian.net/browse/PCD-3880 

### SUMMARY
Refined lease policy logic to prioritize VM-specific configurations over tenant-wide settings.

**Details**
- If a VM lease policy is defined for a specific VM, the tenant lease logic now skips that VM.
- Removed the restriction that prevented a VM lease duration from exceeding the tenant lease duration.
- Ensured the final behavior correctly prioritizes VM-level lease settings, while tenant lease policies apply only to VMs without an explicit VM lease.

This update improves flexibility and ensures lease policies behave as intended in mixed VM and tenant lease scenarios.

### TESTING:
**Manual**:

Validated that VM lease can now be set to a duration greater than the tenant lease.

```
# curl -k -H "X-Auth-Token: $TOKEN" -H "Content-Type: application/json" -i https://pcd-community.pf9.io/mors/v1/tenant/3eb32d4331ba4cab94da3907badd8860/instances
HTTP/2 200 
date: Fri, 10 Oct 2025 18:31:43 GMT
content-type: application/json
content-length: 738
strict-transport-security: max-age=31536000; includeSubDomains

{
  "all_vms": [
    {
      "action": "delete",
      "created_at": "2025-10-10T18:31:39Z",
      "created_by": "c0895fb434b14201a524b0d8f7d7984b",
      "expiry": "2025-10-10T18:54:00Z",
      "instance_uuid": "ffb9e972-7f63-46fc-98ee-a7b1afd99789",
      "tenant_uuid": "3eb32d4331ba4cab94da3907badd8860",
      "updated_at": null,
      "updated_by": null
    }
  ],
  "tenant_lease": {
    "vm_lease_policy": {
      "action": "power off",
      "created_at": "2025-10-10T18:12:23Z",
      "created_by": "c0895fb434b14201a524b0d8f7d7984b",
      "expiry_mins": 12,
      "tenant_uuid": "3eb32d4331ba4cab94da3907badd8860",
      "updated_at": "2025-10-10T18:22:36Z",
      "updated_by": "c0895fb434b14201a524b0d8f7d7984b"
    }
  }
}
```

Validated that during tenant lease processing, VMs with an individual VM lease configured are correctly skipped. Once the VM lease expires, the VM lease policy is applied as expected.

<img width="964" height="391" alt="Screenshot 2025-10-11 at 12 11 44 AM" src="https://github.com/user-attachments/assets/10a4d030-917e-444c-9ccb-5f1f21c5a07a" />

Applies the VM lease policy when the VM lease expires.
`2025-10-10 18:45:33,836 mors.mors.lease_manager INFO Explicit lease for ffb9e972-7f63-46fc-98ee-a7b1afd99789 queueing for deletion`
