### PR TITLE
PCD-6287 mors pod restarting because of liveness failure

### DIFF
--- a/container/etc/confd/templates/pf9-mors-api-paste.ini
+++ b/container/etc/confd/templates/pf9-mors-api-paste.ini
@@ -14,12 +14,14 @@ pipeline = authtoken morsService
 
 [filter:authtoken]
 paste.filter_factory = keystonemiddleware.auth_token:filter_factory
+auth_type = v3password
+auth_url = http://keystone.{{getenv "INFRA_NAMESPACE"}}.svc.cluster.local:5000/keystone/v3
+www_authenticate_uri = http://keystone.{{getenv "INFRA_NAMESPACE"}}.svc.cluster.local:5000/keystone/v3
 username = mors
 password = {{getv "/services/mors/keystone/password"}}
 project_name = services
 user_domain_id = default
 project_domain_id = default
-auth_plugin = v3password
-auth_url = http://keystone.{{getenv "INFRA_NAMESPACE"}}.svc.cluster.local:5000/keystone/v3
 region_name = {{getv "/region_id"}}
 insecure = True
+service_token_roles_required = True

--- a/container/mors_manage.py
+++ b/container/mors_manage.py
@@ -37,7 +37,7 @@ def _version_control(conf):
 if __name__ == '__main__':
     parser = _get_arg_parser()
     conf = ConfigParser()
-    conf.readfp(open(parser.config_file))
+    conf.read_file(open(parser.config_file))
     if 'db_sync' == parser.command:
         _version_control(conf)
         upgrade(conf.get("DEFAULT", "db_conn"), conf.get("DEFAULT", "repo"))

--- a/container/pf9_mors.py
+++ b/container/pf9_mors.py
@@ -75,5 +75,5 @@ def start_server(conf, paste_ini):
 if __name__ == '__main__':
     parser = _get_arg_parser()
     conf = ConfigParser()
-    conf.readfp(open(parser.config_file))
+    conf.read_file(open(parser.config_file))
     start_server(conf, parser.paste_file)

--- a/etc/pf9/pf9-mors-api-paste.ini
+++ b/etc/pf9/pf9-mors-api-paste.ini
@@ -14,10 +14,12 @@ pipeline = authtoken morsService
 
 [filter:authtoken]
 paste.filter_factory = keystonemiddleware.auth_token:filter_factory
+auth_type = v3password
+auth_url = http://localhost:8080/keystone/v3
+www_authenticate_uri = http://localhost:8080/keystone/v3
 username = mors
 password =
 project_name = services
 user_domain_id = default
 project_domain_id = default
-auth_plugin = v3password
-auth_url = http://localhost:8080/keystone/v3
+service_token_roles_required = True

--- a/mors/lease_manager.py
+++ b/mors/lease_manager.py
@@ -146,12 +146,25 @@ class LeaseManager:
 
     def update_instance_lease(self, context, tenant_uuid, instance_lease_obj):
         logger.info("Update instance lease %s", instance_lease_obj)
+
+        current_time = datetime.utcnow()
+        if 'expiry' not in instance_lease_obj or instance_lease_obj['expiry'] <= current_time:
+            raise ValueError("Expiry time must be in the future")
+
+        tenant_lease = self.domain_mgr.get_tenant_lease(tenant_uuid)
+        if tenant_lease:
+            max_expiry = current_time + timedelta(minutes=tenant_lease['expiry_mins'])
+            if instance_lease_obj['expiry'] > max_expiry:
+                raise ValueError(
+                    "Expiry exceeds tenant policy maximum of %d minutes"
+                    % tenant_lease['expiry_mins'])
+
         self.domain_mgr.update_instance_lease(instance_lease_obj['instance_uuid'],
                                             tenant_uuid,
                                             instance_lease_obj['expiry'],
                                             instance_lease_obj['action'],
                                             context.user_id,
-                                            datetime.utcnow())
+                                            current_time)
         
 
     def delete_instance_lease(self, context, instance_uuid):

--- a/mors/leasehandler/nova_lease_handler.py
+++ b/mors/leasehandler/nova_lease_handler.py
@@ -16,9 +16,11 @@ limitations under the License.
 
 from novaclient import client
 import logging
+import time
 import novaclient
 from keystoneauth1.identity import v3
 from keystoneauth1 import session
+from keystoneauth1 import exceptions as ks_exceptions
 from datetime import datetime
 from .constants import SUCCESS_OK, ERR_NOT_FOUND, ERR_UNKNOWN
 from mors.constants import LOGGER_PREFIX
@@ -32,11 +34,14 @@ def get_vm_data(data):
             'tenant_uuid': data.tenant_id,
             'created_at': datetime.strptime(data.created, DATE_FORMAT)}
 
+MAX_AUTH_RETRIES = 3
+AUTH_RETRY_DELAY = 5
+
 class NovaLeaseHandler:
     def __init__(self, conf):
         self.conf = conf
-        self.keystone_sess = self.get_keystone_session()                      
-        self.pf9_project_id = self.keystone_sess.get_project_id()
+        self.keystone_sess = self.get_keystone_session()
+        self.pf9_project_id = self._get_project_id_with_retry()
         self.nova_client = client.Client(self.conf.get("nova", "version"),
                              username=self.conf.get("nova", "user_name"),
                              region_name=self.conf.get("nova", "region_name"),
@@ -51,6 +56,37 @@ class NovaLeaseHandler:
     def _get_nova_client(self):
         return self.nova_client
 
+    def _get_project_id_with_retry(self):
+        auth_url = self.conf.get('nova', 'auth_url')
+        username = self.conf.get('nova', 'user_name')
+        for attempt in range(1, MAX_AUTH_RETRIES + 1):
+            try:
+                project_id = self.keystone_sess.get_project_id()
+                logger.info("Keystone authentication successful (attempt %d/%d)",
+                            attempt, MAX_AUTH_RETRIES)
+                return project_id
+            except ks_exceptions.Unauthorized:
+                logger.error(
+                    "Keystone auth failed (attempt %d/%d): 401 Unauthorized. "
+                    "auth_url=%s, username=%s. Verify credentials and that the "
+                    "user exists in Keystone.",
+                    attempt, MAX_AUTH_RETRIES, auth_url, username)
+            except ks_exceptions.ConnectFailure as e:
+                logger.error(
+                    "Keystone auth failed (attempt %d/%d): unable to connect "
+                    "to %s: %s",
+                    attempt, MAX_AUTH_RETRIES, auth_url, e)
+            except Exception as e:
+                logger.error(
+                    "Keystone auth failed (attempt %d/%d): %s",
+                    attempt, MAX_AUTH_RETRIES, e)
+            if attempt < MAX_AUTH_RETRIES:
+                logger.info("Retrying in %d seconds...", AUTH_RETRY_DELAY)
+                time.sleep(AUTH_RETRY_DELAY)
+        raise RuntimeError(
+            "Failed to authenticate with Keystone after %d attempts. "
+            "auth_url=%s, username=%s" % (MAX_AUTH_RETRIES, auth_url, username))
+
     def get_keystone_session(self):
         auth_params = {
              'auth_url': self.conf.get('nova', 'auth_url'),
@@ -61,7 +97,7 @@ class NovaLeaseHandler:
              'project_domain_id': 'default'
         }
         auth = v3.Password(**auth_params)
-        return session.Session(auth=auth) 
+        return session.Session(auth=auth)
 
     def get_all_vms(self, tenant_uuid):
         """

--- a/mors/mors_manage.py
+++ b/mors/mors_manage.py
@@ -37,7 +37,7 @@ def _version_control(conf):
 if __name__ == '__main__':
     parser = _get_arg_parser()
     conf = ConfigParser()
-    conf.readfp(open(parser.config_file))
+    conf.read_file(open(parser.config_file))
     if 'db_sync' == parser.command:
         _version_control(conf)
         upgrade(conf.get("DEFAULT", "db_conn"), conf.get("DEFAULT", "repo"))

--- a/mors/pf9_mors.py
+++ b/mors/pf9_mors.py
@@ -60,5 +60,5 @@ def start_server(conf, paste_ini):
 if __name__ == '__main__':
     parser = _get_arg_parser()
     conf = ConfigParser()
-    conf.readfp(open(parser.config_file))
+    conf.read_file(open(parser.config_file))
     start_server(conf, parser.paste_file)


### PR DESCRIPTION
Jira :- https://platform9.atlassian.net/browse/PCD-6287

Summary :- The pf9-mors service was crashing on startup with a keystoneauth1.exceptions.http.Unauthorized (HTTP 401) error. The crash happened in NovaLeaseHandler.__init__ when it tried to authenticate with Keystone to get a project ID. A single failed auth attempt would kill the entire process. DeprecationWarning from using the removed ConfigParser.readfp() method "option not known to keystonemiddleware" warnings for username, password, etc. due to using the deprecated auth_plugin config key instead of auth_type
"service_token_roles_required set to False" and missing www_authenticate_uri warnings

Testcase failure fix:-
Two unit tests were also failing because update_instance_lease() had no validation against tenant policy limits.

Testing:-
```
mors-54546d84dd-f7rwh:~# cat /etc/pf9/pf9-mors.ini
[DEFAULT]
db_conn=mysql+pymysql://mors:EbFUOTTsXl6ZkTgB@percona-db-pxc-db-haproxy.airctl-1-4561058-466-blr.svc.cluster.local:3306/mors
context_factory=nova
lease_handler=
listen_port=8989
sleep_seconds=60
paste-ini=/etc/pf9/pf9-mors-api-paste.ini
log_file=/var/log/pf9/pf9-mors.log
log_level=INFO
repo=/usr/local/lib/python3.9/site-packages/mors_repo 

[nova]
user_name=mors
password=uf4tSTjF1uV8L5UF
version=2.1
auth_url=http://keystone.airctl-1-4561058-466.svc.cluster.local:5000/keystone/v3
region_name=BLR
mors-54546d84dd-f7rwh:~# cat /etc/pf9/pf9-mors-api-paste.ini
[app:morsService]
paste.app_factory = mors.mors_wsgi:app_factory

[app:healthService]
paste.app_factory = mors.mors_wsgi:health_app_factory

[composite:main]
use = egg:Paste#urlmap
/health = healthService
/ = authPipeline

[pipeline:authPipeline]
pipeline = authtoken morsService

[filter:authtoken]
paste.filter_factory = keystonemiddleware.auth_token:filter_factory
auth_type = v3password
auth_url = http://keystone.airctl-1-4561058-466.svc.cluster.local:5000/keystone/v3
www_authenticate_uri = http://keystone.airctl-1-4561058-466.svc.cluster.local:5000/keystone/v3
username = mors
password = uf4tSTjF1uV8L5UF
project_name = services
user_domain_id = default
project_domain_id = default
region_name = BLR
insecure = True
service_token_roles_required = True


Logs:-
root@test-pf9-du-host-testbed-only-4561058-00-3:~# kubectl logs -n airctl-1-4561058-466-blr      mors-54546d84dd-f7rwh
2026-04-14 12:56:28,878 CRIT Supervisor is running as root.  Privileges were not dropped because no user is specified in the config file.  If you intend to run as root, you can set user=root in the config file to avoid this message.
2026-04-14 12:56:28,885 INFO RPC interface 'supervisor' initialized
2026-04-14 12:56:28,885 CRIT Server 'unix_http_server' running without any HTTP authentication checking
2026-04-14 12:56:28,886 INFO supervisord started with pid 1
2026-04-14 12:56:29,897 INFO spawned: 'confd' with pid 7
2026-04-14 12:56:29,931 INFO spawned: 'mors' with pid 8
+ python /opt/pf9/pf9-mors/bin/mors_manage.py --command db_sync
2026-04-14T12:56:30Z mors-54546d84dd-f7rwh confd[7]: INFO Backend set to consul
2026-04-14T12:56:30Z mors-54546d84dd-f7rwh confd[7]: INFO Starting confd
2026-04-14T12:56:30Z mors-54546d84dd-f7rwh confd[7]: INFO Backend source(s) set to decco-consul-consul-server.default.svc.cluster.local:8500
2026-04-14T12:56:30Z mors-54546d84dd-f7rwh confd[7]: INFO Target config /etc/pf9/pf9-mors-api-paste.ini out of sync
2026-04-14T12:56:30Z mors-54546d84dd-f7rwh confd[7]: INFO Target config /etc/pf9/pf9-mors-api-paste.ini has been updated
2026-04-14T12:56:30Z mors-54546d84dd-f7rwh confd[7]: INFO Target config /etc/pf9/pf9-mors.ini out of sync
2026-04-14T12:56:30Z mors-54546d84dd-f7rwh confd[7]: INFO Target config /etc/pf9/pf9-mors.ini has been updated
2026-04-14 12:56:31,346 INFO success: confd entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2026-04-14 12:56:31,347 INFO success: mors entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)

+ exec python /opt/pf9/pf9-mors/bin/pf9_mors.py
The option "auth_url" is not known to keystonemiddleware
The option "username" is not known to keystonemiddleware
The option "password" is not known to keystonemiddleware
The option "project_name" is not known to keystonemiddleware
The option "user_domain_id" is not known to keystonemiddleware
The option "project_domain_id" is not known to keystonemiddleware
2026-04-14 12:56:34,963 mors.mors.leasehandler.nova_lease_handler ERROR Keystone auth failed (attempt 1/3): 401 Unauthorized. auth_url=http://keystone.airctl-1-4561058-466.svc.cluster.local:5000/keystone/v3, username=mors. Verify credentials and that the user exists in Keystone.
2026-04-14 12:56:34,964 mors.mors.leasehandler.nova_lease_handler INFO Retrying in 5 seconds...
2026-04-14 12:56:40,085 mors.mors.leasehandler.nova_lease_handler ERROR Keystone auth failed (attempt 2/3): 401 Unauthorized. auth_url=http://keystone.airctl-1-4561058-466.svc.cluster.local:5000/keystone/v3, username=mors. Verify credentials and that the user exists in Keystone.
2026-04-14 12:56:40,087 mors.mors.leasehandler.nova_lease_handler INFO Retrying in 5 seconds...
2026-04-14 12:56:45,182 mors.mors.leasehandler.nova_lease_handler ERROR Keystone auth failed (attempt 3/3): 401 Unauthorized. auth_url=http://keystone.airctl-1-4561058-466.svc.cluster.local:5000/keystone/v3, username=mors. Verify credentials and that the user exists in Keystone.
Traceback (most recent call last):
  File "/opt/pf9/pf9-mors/bin/pf9_mors.py", line 79, in <module>
    start_server(conf, parser.paste_file)
  File "/opt/pf9/pf9-mors/bin/pf9_mors.py", line 71, in start_server
    mors_wsgi.start_server(conf)
  File "/usr/local/lib/python3.9/site-packages/mors/mors_wsgi.py", line 132, in start_server
    lease_manager = LeaseManager(conf)
  File "/usr/local/lib/python3.9/site-packages/mors/lease_manager.py", line 68, in __init__
    self.lease_handler = get_lease_handler(conf)
  File "/usr/local/lib/python3.9/site-packages/mors/leasehandler/__init__.py", line 24, in get_lease_handler
    return NovaLeaseHandler(conf)
  File "/usr/local/lib/python3.9/site-packages/mors/leasehandler/nova_lease_handler.py", line 44, in __init__
    self.pf9_project_id = self._get_project_id_with_retry()
  File "/usr/local/lib/python3.9/site-packages/mors/leasehandler/nova_lease_handler.py", line 86, in _get_project_id_with_retry
    raise RuntimeError(
RuntimeError: Failed to authenticate with Keystone after 3 attempts. auth_url=http://keystone.airctl-1-4561058-466.svc.cluster.local:5000/keystone/v3, username=mors
2026-04-14 12:56:45,509 WARN exited: mors (exit status 1; not expected)
2026-04-14 12:56:46,520 INFO spawned: 'mors' with pid 24
+ python /opt/pf9/pf9-mors/bin/mors_manage.py --command db_sync
2026-04-14 12:56:47,540 INFO success: mors entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)

+ exec python /opt/pf9/pf9-mors/bin/pf9_mors.py
The option "auth_url" is not known to keystonemiddleware
The option "username" is not known to keystonemiddleware
The option "password" is not known to keystonemiddleware
The option "project_name" is not known to keystonemiddleware
The option "user_domain_id" is not known to keystonemiddleware
The option "project_domain_id" is not known to keystonemiddleware
2026-04-14 12:56:50,342 mors.mors.leasehandler.nova_lease_handler ERROR Keystone auth failed (attempt 1/3): 401 Unauthorized. auth_url=http://keystone.airctl-1-4561058-466.svc.cluster.local:5000/keystone/v3, username=mors. Verify credentials and that the user exists in Keystone.
2026-04-14 12:56:50,342 mors.mors.leasehandler.nova_lease_handler INFO Retrying in 5 seconds...
2026-04-14 12:56:56,091 mors.mors.leasehandler.nova_lease_handler ERROR Keystone auth failed (attempt 2/3): 401 Unauthorized. auth_url=http://keystone.airctl-1-4561058-466.svc.cluster.local:5000/keystone/v3, username=mors. Verify credentials and that the user exists in Keystone.
2026-04-14 12:56:56,092 mors.mors.leasehandler.nova_lease_handler INFO Retrying in 5 seconds...
2026-04-14 12:57:01,877 mors.mors.leasehandler.nova_lease_handler INFO Keystone authentication successful (attempt 3/3)
/usr/local/lib/python3.9/site-packages/novaclient/client.py:254: UserWarning: The 'api_key' argument is deprecated in Ocata and its use may result in errors in future releases. Use 'password' instead.
  warnings.warn(msg)
/usr/local/lib/python3.9/site-packages/novaclient/client.py:254: UserWarning: The 'tenant_id' argument is deprecated in Ocata and its use may result in errors in future releases. Use 'project_id' instead.
  warnings.warn(msg)
/usr/local/lib/python3.9/site-packages/novaclient/client.py:254: UserWarning: The 'connection_pool' argument is deprecated in Ocata and its use may result in errors in future releases.
  warnings.warn(msg)
(24) wsgi starting up on http://0.0.0.0:8989
(24) accepted ('10.10.13.38', 55000)
(24) accepted ('10.10.13.38', 55016)
10.10.13.38 - - [14/Apr/2026 12:57:06] "GET /health/live HTTP/1.1" 200 163 0.005637
10.10.13.38 - - [14/Apr/2026 12:57:06] "GET /health/ready HTTP/1.1" 503 223 0.024887
(24) accepted ('10.10.13.38', 45838)


Teamcity tests-https://teamcity.platform9.horse/buildConfiguration/Pf9project_Opencloud_007pcdOnpremTestbedOnly/4561058
```